### PR TITLE
build: cache bazelisk and bazel directories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Cache bazelisk and bazel outputs
+        uses: actions/cache@v2.1.7
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            ~/.cache/bazelisk
+            ~/.cache/bazel
+          key: ${{ runner.os }}-${{ env.cache-name }}
+      
       - uses: actions/checkout@v2
+      
       - name: Build with bazel
         run: bazel build //...
+      
       - name: Test with bazel
         run: bazel test //...


### PR DESCRIPTION
Instead of remote cache we can just restore a local cache from previous builds in Github actions.

It is probably still worth adding a remote cache once cache restores from previous builds takes a long time. It is already ~15s.

Closes #10 