### PR TITLE
build: check commits for validity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  common_ci:
     runs-on: ubuntu-latest
     steps:
       - name: Cache bazel on successful builds
@@ -28,6 +28,12 @@ jobs:
 
       - name: Test with bazel
         run: bazel test //...
+
+  pull_request_ci:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Yarn install
         run: yarn


### PR DESCRIPTION
Separates PR checks from checks on the master branch. 

E.g. we should not need to re validate style on the master branch if it was already done on the PR.