### PR TITLE
feat(journal): add author as example of child data fetcher

### DIFF
--- a/contexts/journal/src/main/java/nz/geek/jack/journal/Author.java
+++ b/contexts/journal/src/main/java/nz/geek/jack/journal/Author.java
@@ -1,0 +1,21 @@
+package nz.geek.jack.journal;
+
+public final class Author {
+
+  private final String id;
+
+  private final String name;
+
+  public Author(String id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/contexts/journal/src/main/java/nz/geek/jack/journal/EntriesDataFetcher.java
+++ b/contexts/journal/src/main/java/nz/geek/jack/journal/EntriesDataFetcher.java
@@ -1,6 +1,8 @@
 package nz.geek.jack.journal;
 
 import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.netflix.graphql.dgs.InputArgument;
 import java.util.List;
@@ -11,11 +13,11 @@ public class EntriesDataFetcher {
 
   private final List<Entry> entries =
       List.of(
-          new Entry("Stranger Things", "2016"),
-          new Entry("Ozark", "2017"),
-          new Entry("The Crown", "2016"),
-          new Entry("Dead to Me", "2019"),
-          new Entry("Orange is the New Black", "2013"));
+          new Entry("1", "Stranger Things", "2016"),
+          new Entry("2", "Ozark", "2017"),
+          new Entry("3", "The Crown", "2016"),
+          new Entry("4", "Dead to Me", "2019"),
+          new Entry("5", "Orange is the New Black", "2013"));
 
   @DgsQuery
   public List<Entry> allEntries(@InputArgument String entryFilter) {
@@ -26,5 +28,11 @@ public class EntriesDataFetcher {
     return entries.stream()
         .filter(s -> s.getMessage().contains(entryFilter))
         .collect(Collectors.toList());
+  }
+
+  @DgsData(parentType = "Entry")
+  public Author author(DgsDataFetchingEnvironment dfe) {
+    Entry entry = dfe.getSource();
+    return new Author("1", String.format("%s Author", entry.getMessage()));
   }
 }

--- a/contexts/journal/src/main/java/nz/geek/jack/journal/Entry.java
+++ b/contexts/journal/src/main/java/nz/geek/jack/journal/Entry.java
@@ -1,13 +1,19 @@
 package nz.geek.jack.journal;
 
-public class Entry {
+public final class Entry {
 
+  private final String id;
   private final String message;
   private final String createdAt;
 
-  public Entry(String message, String createdAt) {
+  public Entry(String id, String message, String createdAt) {
+    this.id = id;
     this.message = message;
     this.createdAt = createdAt;
+  }
+
+  public String getId() {
+    return id;
   }
 
   public String getMessage() {

--- a/contexts/journal/src/main/resources/schema/schema.graphqls
+++ b/contexts/journal/src/main/resources/schema/schema.graphqls
@@ -6,4 +6,10 @@ type Entry {
   id: ID!
   message: String!
   createdAt: String!
+  author: Author!
+}
+
+type Author {
+  id: ID!
+  name: String!
 }


### PR DESCRIPTION
Child data fetchers add the ability to split the loading of the main type, from its relations which might be a costly load to do when it is not necessary.