### PR TITLE
chore: align kafka test container with compose version

### DIFF
--- a/learn/testcontainers/src/test/java/nz/geek/jack/learn/testcontainers/kafka/KafkaTest.java
+++ b/learn/testcontainers/src/test/java/nz/geek/jack/learn/testcontainers/kafka/KafkaTest.java
@@ -22,7 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 public class KafkaTest {
   @Container
   public KafkaContainer kafka =
-      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));
+      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3"));
 
   @Test
   public void getBootstrapServers_isNotBlank() {


### PR DESCRIPTION
Reduce disk consumption by pulling same image as other parts of the repo.