### PR TITLE
ci: fix missing coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,10 +67,11 @@ jobs:
             $(bazel query 'kind("java_test", //...)')
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./dist/out/_coverage/_coverage_report.dat
+          fail_ci_if_error: true
 
   pull_request_ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
v4 has a regression: https://github.com/codecov/engineering-team/issues/1143

Reverting until it is fixed. Added `fail_ci_if_error` to catch upgrade regressions in the future.