### PR TITLE
feat(mops): get default budget

### DIFF
--- a/services/mops/src/main/java/nz/geek/jack/mops/core/BUILD.bazel
+++ b/services/mops/src/main/java/nz/geek/jack/mops/core/BUILD.bazel
@@ -7,5 +7,6 @@ java_library(
         "//services/mops/src/main/java/nz/geek/jack/mops/core/adapter/api/gql/budget",
         "//services/mops/src/main/java/nz/geek/jack/mops/core/adapter/api/gql/category",
         "//services/mops/src/main/java/nz/geek/jack/mops/core/adapter/api/gql/lineitem",
+        "//services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup",
     ],
 )

--- a/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/api/gql/budget/BudgetDataFetcher.java
+++ b/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/api/gql/budget/BudgetDataFetcher.java
@@ -1,0 +1,28 @@
+package nz.geek.jack.mops.core.adapter.api.gql.budget;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import java.util.List;
+import java.util.stream.Collectors;
+import nz.geek.jack.mops.api.gql.types.Budget;
+import nz.geek.jack.mops.core.application.budget.BudgetQueryService;
+
+@DgsComponent
+public class BudgetDataFetcher {
+
+  private final BudgetQueryService budgetQueryService;
+
+  private final BudgetMapper budgetMapper;
+
+  public BudgetDataFetcher(BudgetQueryService budgetQueryService, BudgetMapper budgetMapper) {
+    this.budgetQueryService = budgetQueryService;
+    this.budgetMapper = budgetMapper;
+  }
+
+  @DgsQuery
+  public List<Budget> allBudgets() {
+    return budgetQueryService.findAll().stream()
+        .map(budgetMapper::map)
+        .collect(Collectors.toList());
+  }
+}

--- a/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup/BUILD.bazel
+++ b/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup/BUILD.bazel
@@ -1,0 +1,13 @@
+java_library(
+    name = "startup",
+    srcs = glob(["*.java"]),
+    visibility = [
+        "//services/mops/src/main/java/nz/geek/jack/mops/core:__pkg__",
+        "//services/mops/src/test/java/nz/geek/jack/mops/core/adapter/startup:__pkg__",
+    ],
+    deps = [
+        "//services/mops/src/main/java/nz/geek/jack/mops/core/application/budget",
+        "@maven//:org_springframework_boot_spring_boot",
+        "@maven//:org_springframework_spring_context",
+    ],
+)

--- a/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup/BudgetCreator.java
+++ b/services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup/BudgetCreator.java
@@ -1,0 +1,36 @@
+package nz.geek.jack.mops.core.adapter.startup;
+
+import nz.geek.jack.mops.core.application.budget.BudgetCommandService;
+import nz.geek.jack.mops.core.application.budget.BudgetQueryService;
+import nz.geek.jack.mops.core.application.budget.CreateBudgetCommand;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BudgetCreator {
+
+  protected static final String DEFAULT_BUDGET_NAME = "Default";
+
+  private final BudgetQueryService budgetQueryService;
+
+  private final BudgetCommandService budgetCommandService;
+
+  public BudgetCreator(
+      BudgetQueryService budgetQueryService, BudgetCommandService budgetCommandService) {
+    this.budgetQueryService = budgetQueryService;
+    this.budgetCommandService = budgetCommandService;
+  }
+
+  @EventListener(ApplicationStartedEvent.class)
+  public void onApplicationStarted() {
+    if (budgetQueryService.findAll().isEmpty()) {
+      createDefaultBudget();
+    }
+  }
+
+  private void createDefaultBudget() {
+    var command = new CreateBudgetCommand(DEFAULT_BUDGET_NAME);
+    budgetCommandService.create(command);
+  }
+}

--- a/services/mops/src/main/java/nz/geek/jack/mops/core/application/budget/BudgetQueryService.java
+++ b/services/mops/src/main/java/nz/geek/jack/mops/core/application/budget/BudgetQueryService.java
@@ -1,0 +1,20 @@
+package nz.geek.jack.mops.core.application.budget;
+
+import java.util.Collection;
+import nz.geek.jack.mops.core.domain.budget.Budget;
+import nz.geek.jack.mops.core.domain.budget.BudgetRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BudgetQueryService {
+
+  private final BudgetRepository budgetRepository;
+
+  public BudgetQueryService(BudgetRepository budgetRepository) {
+    this.budgetRepository = budgetRepository;
+  }
+
+  public Collection<Budget> findAll() {
+    return budgetRepository.findAll();
+  }
+}

--- a/services/mops/src/main/resources/schema/schema.graphqls
+++ b/services/mops/src/main/resources/schema/schema.graphqls
@@ -1,6 +1,7 @@
 # API root
 
 type Query {
+  allBudgets: [Budget!]!
   allLineItems: [LineItem!]!
   allCategories: [Category!]!
   clientConfiguration: ClientConfiguration!

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/api/gql/budget/BudgetDataFetcherTest.java
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/api/gql/budget/BudgetDataFetcherTest.java
@@ -1,0 +1,40 @@
+package nz.geek.jack.mops.core.adapter.api.gql.budget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import nz.geek.jack.mops.api.gql.types.Budget;
+import nz.geek.jack.mops.core.application.budget.BudgetQueryService;
+import nz.geek.jack.test.TestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetDataFetcherTest extends TestBase {
+
+  @Mock BudgetQueryService budgetQueryService;
+
+  @Mock BudgetMapper budgetMapper;
+
+  @InjectMocks BudgetDataFetcher budgetDataFetcher;
+
+  @Test
+  void allCategories_mapsCategories() {
+    var domainBudget = newBudget();
+    var graphBudget = Budget.newBuilder().build();
+    when(budgetQueryService.findAll()).thenReturn(List.of(domainBudget));
+    when(budgetMapper.map(domainBudget)).thenReturn(graphBudget);
+
+    var result = budgetDataFetcher.allBudgets();
+
+    assertThat(result).contains(graphBudget);
+  }
+
+  private nz.geek.jack.mops.core.domain.budget.Budget newBudget() {
+    return nz.geek.jack.mops.core.domain.budget.Budget.create(randomString());
+  }
+}

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/startup/BUILD.bazel
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/startup/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//tools/bazel:java.bzl", "java_test_suite")
+
+java_test_suite(
+    name = "startup",
+    deps = [
+        "//services/mops/src/main/java/nz/geek/jack/mops/core/adapter/startup",
+        "//services/mops/src/main/java/nz/geek/jack/mops/core/application/budget",
+        "//services/mops/src/main/java/nz/geek/jack/mops/core/domain/budget",
+    ],
+)

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/startup/BudgetCreatorTest.java
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/adapter/startup/BudgetCreatorTest.java
@@ -1,0 +1,47 @@
+package nz.geek.jack.mops.core.adapter.startup;
+
+import static nz.geek.jack.mops.core.adapter.startup.BudgetCreator.DEFAULT_BUDGET_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import nz.geek.jack.mops.core.application.budget.BudgetCommandService;
+import nz.geek.jack.mops.core.application.budget.BudgetQueryService;
+import nz.geek.jack.mops.core.application.budget.CreateBudgetCommand;
+import nz.geek.jack.mops.core.domain.budget.Budget;
+import nz.geek.jack.test.TestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetCreatorTest extends TestBase {
+
+  @Mock BudgetQueryService budgetQueryService;
+
+  @Mock BudgetCommandService budgetCommandService;
+
+  @InjectMocks BudgetCreator budgetCreator;
+
+  @Test
+  void onApplicationStarted_createsDefaultBudgetIfNotPresent() {
+    when(budgetQueryService.findAll()).thenReturn(List.of());
+
+    budgetCreator.onApplicationStarted();
+
+    verify(budgetCommandService).create(new CreateBudgetCommand(DEFAULT_BUDGET_NAME));
+  }
+
+  @Test
+  void onApplicationStarted_wontCreatesDefaultBudgetIfPresent() {
+    when(budgetQueryService.findAll()).thenReturn(List.of(Budget.create(DEFAULT_BUDGET_NAME)));
+
+    budgetCreator.onApplicationStarted();
+
+    verify(budgetCommandService, never()).create(any());
+  }
+}

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/application/budget/BudgetQueryServiceTest.java
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/application/budget/BudgetQueryServiceTest.java
@@ -1,0 +1,32 @@
+package nz.geek.jack.mops.core.application.budget;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import nz.geek.jack.mops.core.domain.budget.Budget;
+import nz.geek.jack.mops.core.domain.budget.BudgetRepository;
+import nz.geek.jack.test.TestBase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetQueryServiceTest extends TestBase {
+
+  @Mock BudgetRepository budgetRepository;
+
+  @InjectMocks BudgetQueryService budgetQueryService;
+
+  @Test
+  void findAll_delegatesToRepository() {
+    var budgets = List.of(Budget.create(randomString()));
+    when(budgetRepository.findAll()).thenReturn(budgets);
+
+    budgetQueryService.findAll();
+
+    verify(budgetRepository).findAll();
+  }
+}

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/functional/BudgetFunctionalTest.java
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/functional/BudgetFunctionalTest.java
@@ -27,4 +27,16 @@ class BudgetFunctionalTest extends TestBase {
     assertThat(response.getBudget().getId()).isNotBlank();
     assertThat(response.getBudget().getName()).isEqualTo(name);
   }
+
+  @Test
+  void allBudgets_returnsAllBudgets() {
+    var name = randomString();
+
+    client.createBudget(name);
+
+    var budgets = client.allBudgets();
+
+    assertThat(budgets.size()).isEqualTo(2); // Default + added
+    assertThat(budgets.get(1).getName()).isEqualTo(name);
+  }
 }

--- a/services/mops/src/test/java/nz/geek/jack/mops/core/functional/TestClient.java
+++ b/services/mops/src/test/java/nz/geek/jack/mops/core/functional/TestClient.java
@@ -1,5 +1,6 @@
 package nz.geek.jack.mops.core.functional;
 
+import com.jayway.jsonpath.TypeRef;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
 import java.util.List;
@@ -7,6 +8,8 @@ import nz.geek.jack.mops.api.gql.client.AddCategoryValueGraphQLQuery;
 import nz.geek.jack.mops.api.gql.client.AddCategoryValueProjectionRoot;
 import nz.geek.jack.mops.api.gql.client.AddLineItemGraphQLQuery;
 import nz.geek.jack.mops.api.gql.client.AddLineItemProjectionRoot;
+import nz.geek.jack.mops.api.gql.client.AllBudgetsGraphQLQuery;
+import nz.geek.jack.mops.api.gql.client.AllBudgetsProjectionRoot;
 import nz.geek.jack.mops.api.gql.client.CategorizeLineItemGraphQLQuery;
 import nz.geek.jack.mops.api.gql.client.CategorizeLineItemProjectionRoot;
 import nz.geek.jack.mops.api.gql.client.CreateBudgetGraphQLQuery;
@@ -25,6 +28,7 @@ import nz.geek.jack.mops.api.gql.types.AddCategoryValueInput;
 import nz.geek.jack.mops.api.gql.types.AddCategoryValueResponse;
 import nz.geek.jack.mops.api.gql.types.AddLineItemInput;
 import nz.geek.jack.mops.api.gql.types.AddLineItemResponse;
+import nz.geek.jack.mops.api.gql.types.Budget;
 import nz.geek.jack.mops.api.gql.types.CategorizationInput;
 import nz.geek.jack.mops.api.gql.types.CategorizeLineItemInput;
 import nz.geek.jack.mops.api.gql.types.CategorizeLineItemResponse;
@@ -57,6 +61,16 @@ public class TestClient {
 
     return dgsQueryExecutor.executeAndExtractJsonPathAsObject(
         request.serialize(), "data.createBudget", CreateBudgetResponse.class);
+  }
+
+  public List<Budget> allBudgets() {
+    var request =
+        new GraphQLQueryRequest(
+            AllBudgetsGraphQLQuery.newRequest().build(),
+            new AllBudgetsProjectionRoot<>().id().name());
+
+    return dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+        request.serialize(), "data.allBudgets", new TypeRef<>() {});
   }
 
   public AddLineItemResponse addLineItem(String name) {


### PR DESCRIPTION
This pull request introduces a new GraphQL query for fetching all budgets and adds functionality to create a default budget on application startup if none exist. It includes changes to the core application, GraphQL schema, and test cases to support these features.

### New GraphQL Query for Budgets:
* Added a new `allBudgets` query in the GraphQL schema to fetch all budgets 

### Default Budget Creation on Startup:
* Introduced `BudgetCreator` to create a default budget during application startup if no budgets exist 

### Supporting Core Services:
* Added `BudgetQueryService` to fetch budgets from the repository 

### Functional Testing:
* Extended the functional test client to support the `allBudgets` query and added a functional test to verify the query's behavior 