### PR TITLE
build: enable local disk cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,9 +10,9 @@ import %workspace%/.aspect/bazelrc/performance.bazelrc
 
 # The full list of Bazel options: https://docs.bazel.build/versions/master/command-line-reference.html
 
-# Cache action outputs on disk so they persist across output_base and bazel shutdown (eg. changing branches)
-# Disabled to reduce disk space in CI, could be enabled for local only?
-# build --disk_cache=~/.cache/bazel-disk-cache
+# Cache action outputs on disk so they persist across output_base and bazel shutdown (eg. changing branches).
+# CI overrides this to keep runners small.
+build --disk_cache=~/.cache/bazel-disk-cache
 
 # Bazel will create symlinks from the workspace directory to output artifacts.
 # Build results will be placed in a directory called "dist/bin"

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,3 +1,5 @@
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://remote.buildbuddy.io
 build --remote_cache=grpcs://remote.buildbuddy.io
+# Keep CI runners small; local dev enables disk cache in .bazelrc.
+build --disk_cache=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,4 @@ Use this file to capture working notes, conventions, and repo-specific gotchas. 
 - 2026-02-07: Set organizer e2e and task test suite timeouts to `short` to match observed runtimes.
 - 2026-02-07: Removed root `//:__pkg__` visibility from organizer-local targets after hoisting.
 - 2026-02-07: Added `projects/mops/README.md` with Mops quickstart commands and agent-focused project map.
+- 2026-02-09: Enabled local Bazel disk cache by default with CI explicitly disabling it.


### PR DESCRIPTION
- closes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled local build disk caching by default to speed up developer builds; CI explicitly keeps runners small by disabling the cache.

* **Documentation**
  * Updated documentation to note the new local cache default and the CI override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->