### PR TITLE
Group Renovate minor and patch updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,4 @@ Use this file to capture working notes, conventions, and repo-specific gotchas. 
 - 2026-02-11: Switched DGS srcjar creation in `tools/bazel/dgs/codegen.bzl` from host `zip` to Bazel `@bazel_tools//tools/zip:zipper` for hermetic archive creation.
 - 2026-02-11: DGS srcjar creation now uses `ctx.actions.run` with zipper and `Args.add_all(..., expand_directories=True, map_each=...)`; `map_each` must be a top-level Starlark function.
 - 2026-02-11: For validation, run standard Bazel commands first (for example `bazel test //<PATH>/...`) with the default output base; only use debug flags or custom `--output_base` after a reproducible failure and note why.
+- 2026-02-11: Configured `renovate.json` to group all minor and patch dependency updates into a single non-major PR stream.

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"]
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependency updates",
+      "groupSlug": "all-non-major-updates"
+    }
+  ]
 }


### PR DESCRIPTION
**Summary**
- add a Renovate package rule that groups all minor and patch dependency updates into a single non-major stream
- document the new grouping rule in `AGENTS.md`

**Testing**
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Refined dependency management workflow by consolidating all minor and patch updates into a single, unified pull request group, reducing the volume of dependency updates and streamlining the review process for teams managing project dependencies
- Enhanced workflow documentation to capture the updated dependency grouping strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->