### PR TITLE
Add a Codex cloud test filter for Docker-dependent suites

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,6 +45,10 @@ coverage --test_tag_filters=-no-coverage
 # Only build what is needed for coverage
 coverage --build_tests_only
 
+# Remote Codex cloud environments run without Docker access.
+test:codex-cloud --test_tag_filters=-requires-docker
+coverage:codex-cloud --test_tag_filters=-requires-docker,-no-coverage
+
 ### NO MORE PROJECT SPECIFIC OPTIONS AFTER HERE ###
 
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Keep this file focused on actionable context that improves execution quality and
 
 - Common command: `bazel build //...`.
 - Common command: `bazel test //...`.
+- Remote Codex cloud command: `bazel test --config=codex-cloud //...` to exclude Docker-dependent tests.
 - Target pattern: `bazel <command> //<PATH_TO_PROJECT>:<TARGETS>`.
 - Commit messages follow Conventional Commits (`docs/style.md`).
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -658,7 +658,7 @@
         "bzlTransitiveDigest": "4u3D2Q8KMDICnG3iuTymzgYbT7m2jCBOpw/XEDnM+jM=",
         "usagesDigest": "r4NUgxQE957p2kkhVEgIoSH0kfzVEyFLLzN40ra5yJw=",
         "recordedFileInputs": {
-          "@@//package.json": "1364943cd34b6471bf2d625ca98c954686a8a35ca575c66dfb51af95e96ccb83"
+          "@@//package.json": "784e30b882f84b5268252153e2966b44bc69c2a450c8beb6291ba791eb129098"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/learn/testcontainers/src/test/java/lab/learn/testcontainers/kafka/BUILD.bazel
+++ b/learn/testcontainers/src/test/java/lab/learn/testcontainers/kafka/BUILD.bazel
@@ -2,7 +2,10 @@ load("//tools/bazel:java.bzl", "java_test_suite")
 
 java_test_suite(
     name = "tests",
-    tags = ["requires-network"],
+    tags = [
+        "requires-docker",
+        "requires-network",
+    ],
     deps = [
         "@maven//:org_apache_kafka_kafka_clients",
         "@maven//:org_testcontainers_junit_jupiter",

--- a/learn/testcontainers/src/test/java/lab/learn/testcontainers/postgres/BUILD.bazel
+++ b/learn/testcontainers/src/test/java/lab/learn/testcontainers/postgres/BUILD.bazel
@@ -2,7 +2,10 @@ load("//tools/bazel:java.bzl", "java_test_suite")
 
 java_test_suite(
     name = "tests",
-    tags = ["requires-network"],
+    tags = [
+        "requires-docker",
+        "requires-network",
+    ],
     runtime_deps = [
         "@maven//:org_postgresql_postgresql",
     ],

--- a/learn/testcontainers/src/test/java/lab/learn/testcontainers/redis/BUILD.bazel
+++ b/learn/testcontainers/src/test/java/lab/learn/testcontainers/redis/BUILD.bazel
@@ -2,7 +2,10 @@ load("//tools/bazel:java.bzl", "java_test_suite")
 
 java_test_suite(
     name = "tests",
-    tags = ["requires-network"],
+    tags = [
+        "requires-docker",
+        "requires-network",
+    ],
     deps = [
         "@maven//:org_testcontainers_junit_jupiter",
         "@maven//:org_testcontainers_testcontainers",

--- a/libs/ddd/src/test/java/lab/libs/ddd/es/persistence/BUILD.bazel
+++ b/libs/ddd/src/test/java/lab/libs/ddd/es/persistence/BUILD.bazel
@@ -2,7 +2,10 @@ load("//tools/bazel:java.bzl", "SPRING_TEST_DEPS", "SPRING_TEST_RUNTIME_DEPS", "
 
 java_test_suite(
     name = "persistence",
-    tags = ["requires-network"],
+    tags = [
+        "requires-docker",
+        "requires-network",
+    ],
     runtime_deps = SPRING_TEST_RUNTIME_DEPS + [
         "@maven//:org_postgresql_postgresql",
         "@maven//:org_springframework_boot_spring_boot_starter_jdbc",


### PR DESCRIPTION
## Summary
- Add a `codex-cloud` Bazel config that excludes `requires-docker` tests for remote Codex environments.
- Tag the Java Testcontainers suites that truly need Docker so they are filtered out cleanly.
- Document the cloud-safe test command in `AGENTS.md`.

## Testing
- Ran `bazel test --config=codex-cloud //...` successfully.
- Verified the Docker tag filter excludes the intended test targets while leaving the rest of the suite available.