### PR TITLE
Adopt Renovate best-practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
+  "extends": ["config:best-practices"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- Switch Renovate to `config:best-practices`
- Keep the existing dependency dashboard and custom grouping rules
- Include the lockfile and app updates already present on this branch

## Testing
- Not run (not requested)