### PR TITLE
Upgrade Confluent dev images to 8.2.1 and switch Kafka to KRaft

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,6 @@ Keep this file focused on actionable context that improves execution quality and
 - Symptom: `bazel run @pnpm//:pnpm ... install --lockfile-only` updates files outside workspace.
   Cause: pnpm runs in Bazel execroot by default.
   Fix: Always pass `--dir $PWD` for lockfile operations.
-- Symptom: `VerifyError` in `ProtobufSchema.toProtoFile` with `kafka-protobuf-serializer`.
-  Cause: `io.confluent:kafka-protobuf-serializer:7.9.5` incompatible with protobuf runtime `4.33.4`.
-  Fix: Use `io.confluent:kafka-protobuf-serializer:8.0.0`.
 - Symptom: DGS schema/resource duplication in test runtime classpath.
   Cause: `contrib_rules_jvm` `java_test_suite` propagates `resources` through generated helper libs.
   Fix: Move schema files to a dedicated `test_resources` `java_library` in `runtime_deps`, not suite-level `resources`.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,7 +90,7 @@ maven.install(
         "com.netflix.graphql.dgs:dgs-starter-test",
         "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
         "jakarta.servlet:jakarta.servlet-api",
-        "io.confluent:kafka-protobuf-serializer:8.2.0",
+        "io.confluent:kafka-protobuf-serializer:8.2.1",
         "org.wiremock:wiremock-jetty12:3.13.2",
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core:7.0.3",
         "com.github.ajalt.clikt:clikt-jvm:4.4.0",  # explicitly depend on the jvm version rather than the kotlin one linked from com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -26,7 +26,6 @@
     "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.2/MODULE.bazel": "30dfabbfae0139b1f0036e01c201dd4c0167da3017f0b7ef3820d78e07622989",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/MODULE.bazel": "004ba890363d05372a97248c37205ae64b6fa31047629cd2c0895a9d0c7779e8",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
@@ -36,8 +35,8 @@
     "https://bcr.bazel.build/modules/aspect_rules_cypress/0.7.2/MODULE.bazel": "6ea99980c4b80bd7c71b6e748dfc2bb46d5a7b7b03c9975b8fe7c8b9fd7e724f",
     "https://bcr.bazel.build/modules/aspect_rules_cypress/0.7.2/source.json": "1ab4266290f60274835908edbc990dcf6d38e17bb932f3d36ca822c6025db2a9",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
-    "https://bcr.bazel.build/modules/aspect_rules_js/2.9.2/MODULE.bazel": "93fd5b85e6e912fb0712cbab453c43271d4ea33a093f84fd587638fbc9f8c145",
-    "https://bcr.bazel.build/modules/aspect_rules_js/2.9.2/source.json": "4bff7c03ab387b60deb15649ba575688e62f2a71a7544cbc7a660b19ec473808",
+    "https://bcr.bazel.build/modules/aspect_rules_js/3.1.2/MODULE.bazel": "e3685502155d3cc65f3bf98e714f7435de67d7f8f355d63478a80197310311fc",
+    "https://bcr.bazel.build/modules/aspect_rules_js/3.1.2/source.json": "a32ab71831452b945f3f83a1b1feb9402007e600bce55ac76e15ef0c1e08b520",
     "https://bcr.bazel.build/modules/aspect_rules_swc/2.6.2/MODULE.bazel": "4ce939429dfb5fa4317862ece399151bd2e65369084fba85df4a3201ae7be26d",
     "https://bcr.bazel.build/modules/aspect_rules_swc/2.6.2/source.json": "f19b5055c46f5d35b4b2edf0800230784193c863e1575a2d3424c4ec11df75d8",
     "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.5/MODULE.bazel": "bcf8f0b6b9375f0f74451e2f70671efae9bb366acef8fdc04675305eaf137f06",
@@ -65,14 +64,17 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.31.0/MODULE.bazel": "eca40770b202b2161c1e20be7f1c323c8836dc959ae48dcf02ee7a051ffe4e8e",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
+    "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.39.0/MODULE.bazel": "28739425c1fc283c91931619749c832b555e60bcd1010b40d8441ce0a5cf726d",
-    "https://bcr.bazel.build/modules/bazel_features/1.39.0/source.json": "f63cbeb4c602098484d57001e5a07d31cb02bbccde9b5e2c9bf0b29d05283e93",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.41.0/MODULE.bazel": "6e0f87fafed801273c371d41e22a15a6f8abf83fdd7f87d5e44ad317b94433d0",
+    "https://bcr.bazel.build/modules/bazel_features/1.41.0/source.json": "8fd525b31b0883c47e0593443cdd10219b94a7556b3195fc02d75c86c66cfe30",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_lib/3.0.0-rc.0/MODULE.bazel": "d6e00979a98ac14ada5e31c8794708b41434d461e7e7ca39b59b765e6d233b18",
     "https://bcr.bazel.build/modules/bazel_lib/3.0.0/MODULE.bazel": "22b70b80ac89ad3f3772526cd9feee2fa412c2b01933fea7ed13238a448d370d",
-    "https://bcr.bazel.build/modules/bazel_lib/3.0.0/source.json": "895f21909c6fba01d7c17914bb6c8e135982275a1b18cdaa4e62272217ef1751",
+    "https://bcr.bazel.build/modules/bazel_lib/3.2.2/MODULE.bazel": "e2c890c8a515d6bca9c66d47718aa9e44b458fde64ec7204b8030bf2d349058c",
+    "https://bcr.bazel.build/modules/bazel_lib/3.2.2/source.json": "9e84e115c20e14652c5c21401ae85ff4daa8702e265b5c0b3bf89353f17aa212",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
@@ -85,7 +87,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.1/MODULE.bazel": "02a13b77321773b2042e70ee5e4c5e099c8ddee4cf2da9cd420442c36938d4bd",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.4/MODULE.bazel": "460aa12d01231a80cce03c548287b433b321d205b0028ae596728c35e5ee442e",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.4/source.json": "d353c410d47a8b65d09fa98e83d57ebec257a2c2b9c6e42d6fda1cb25e5464a5",
@@ -100,7 +103,8 @@
     "https://bcr.bazel.build/modules/download_utils/1.0.1/MODULE.bazel": "f1d0afade59e37de978506d6bbf08d7fe5f94964e86944aaf58efcead827b41b",
     "https://bcr.bazel.build/modules/download_utils/1.0.1/source.json": "05ddc5a3b1f7d8f3e5e0fd1617479e1cf72d63d59ab2b1f0463557a14fc6be0a",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/MODULE.bazel": "cdf8cbe5ee750db04b78878c9633cc76e80dcf4416cbe982ac3a9222f80713c8",
-    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.1/source.json": "fa7b512dfcb5eafd90ce3959cf42a2a6fe96144ebbb4b3b3928054895f2afac2",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
+    "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/source.json": "ebe931bfe362e4b41e59ee00a528db6074157ff2ced92eb9e970acab2e1089c9",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
     "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
     "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
@@ -116,7 +120,8 @@
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
-    "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
@@ -178,6 +183,7 @@
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/source.json": "d03d5cde49376d87e14ec14b666c56075e5e3926930327fd5d0484a1ff2ac1cc",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_coreutils/1.0.1/MODULE.bazel": "2cf97290414a2bd94f742f2cb5c46a624b3eaaebd0d2a8a5f5008cb49bf9e435",
     "https://bcr.bazel.build/modules/rules_coreutils/1.0.1/source.json": "a5c4fb5ac41b687b21e336bc541156ba01a91f25990743ccb768de682305fc26",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
@@ -234,7 +240,6 @@
     "https://bcr.bazel.build/modules/rules_multitool/1.11.1/MODULE.bazel": "f826d2d394e8d964e44ebb4a75ebcfe4e9cd4eb150e2ddcd60398ffeb939696a",
     "https://bcr.bazel.build/modules/rules_multitool/1.11.1/source.json": "201f43de1d35bd17f25a4fed3ba5a2ec500ef5e08b7d4b341bb9fd39cef0cbc6",
     "https://bcr.bazel.build/modules/rules_nodejs/6.2.0/MODULE.bazel": "ec27907f55eb34705adb4e8257952162a2d4c3ed0f0b3b4c3c1aad1fac7be35e",
-    "https://bcr.bazel.build/modules/rules_nodejs/6.3.3/MODULE.bazel": "b66eadebd10f1f1b25f52f95ab5213a57e82c37c3f656fcd9a57ad04d2264ce7",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/MODULE.bazel": "c22a48b2a0dbf05a9dc5f83837bbc24c226c1f6e618de3c3a610044c9f336056",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/source.json": "a3f966f4415a8a6545e560ee5449eac95cc633f96429d08e87c87775c72f5e09",
     "https://bcr.bazel.build/modules/rules_oci/2.2.7/MODULE.bazel": "f6150e4b224d459f7f6523ef65967464ca4efdd266c7fbf2f5a2a51011957e0c",
@@ -289,16 +294,17 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/tar.bzl/0.10.4/MODULE.bazel": "e8f9ff79199e8d9eaad7f1b0a77ad74b30bb82d794b87d8ca942bead5de83ae9",
+    "https://bcr.bazel.build/modules/tar.bzl/0.10.4/source.json": "20143442376c03426f6135292ba02d825cb75308aa47e6bf42dd4cc5a435c2ff",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
-    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
     "https://bcr.bazel.build/modules/toolchain_utils/1.0.2/MODULE.bazel": "9b8be503a4fcfd3b8b952525bff0869177a5234d5c35dc3e566b9f5ca2f755a1",
     "https://bcr.bazel.build/modules/toolchain_utils/1.0.2/source.json": "88769ec576dddacafd8cca4631812cf8eead89f10a29d9405d9f7a553de6bf87",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
-    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
-    "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.4/MODULE.bazel": "d3a270662f5d766cd7229732d65a5a5bc485240c3007343dd279edfb60c9ae27",
+    "https://bcr.bazel.build/modules/yq.bzl/0.3.4/source.json": "786dafdc2843722da3416e4343ee1a05237227f068590779a6e8496a2064c0f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
@@ -384,162 +390,6 @@
             "aspect_rules_cypress~",
             "aspect_rules_cypress",
             "aspect_rules_cypress~"
-          ]
-        ]
-      }
-    },
-    "@@aspect_rules_js~//npm:extensions.bzl%pnpm": {
-      "general": {
-        "bzlTransitiveDigest": "vf3Jqp8ZDL82PR4WVjbfTYc2NgZqQoLwYXBgP3MnQeQ=",
-        "usagesDigest": "nTFJ5zGnx6Y0egMXd24VdeA1weZDnmeWA4aQF3T6/dA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "pnpm": {
-            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
-            "ruleClassName": "npm_import_rule",
-            "attributes": {
-              "package": "pnpm",
-              "version": "10.30.2",
-              "root_package": "",
-              "link_workspace": "",
-              "link_packages": {},
-              "integrity": "sha512-Ns3HB+e3lAqYjJwez4jQhPhRS1w/CF9TouJEwpIdOyVFvCDdTr4fwkX+7EY7spiuzqemPtH3aAuHfcY3nY0MtA==",
-              "url": "",
-              "commit": "",
-              "patch_args": [
-                "-p0"
-              ],
-              "patches": [],
-              "custom_postinstall": "",
-              "npm_auth": "",
-              "npm_auth_basic": "",
-              "npm_auth_username": "",
-              "npm_auth_password": "",
-              "lifecycle_hooks": [],
-              "extra_build_content": "load(\"@aspect_rules_js//js:defs.bzl\", \"js_binary\")\njs_binary(name = \"pnpm\", data = glob([\"package/**\"]), entry_point = \"package/dist/pnpm.cjs\", visibility = [\"//visibility:public\"])",
-              "generate_bzl_library_targets": false,
-              "extract_full_archive": true,
-              "exclude_package_contents": []
-            }
-          },
-          "pnpm__links": {
-            "bzlFile": "@@aspect_rules_js~//npm/private:npm_import.bzl",
-            "ruleClassName": "npm_import_links",
-            "attributes": {
-              "package": "pnpm",
-              "version": "10.30.2",
-              "dev": false,
-              "root_package": "",
-              "link_packages": {},
-              "deps": {},
-              "transitive_closure": {},
-              "lifecycle_build_target": false,
-              "lifecycle_hooks_env": [],
-              "lifecycle_hooks_execution_requirements": [
-                "no-sandbox"
-              ],
-              "lifecycle_hooks_use_default_shell_env": false,
-              "bins": {},
-              "package_visibility": [
-                "//visibility:public"
-              ],
-              "replace_package": "",
-              "exclude_package_contents": []
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "aspect_bazel_lib~",
-            "bazel_lib",
-            "bazel_lib~"
-          ],
-          [
-            "aspect_bazel_lib~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "aspect_bazel_lib~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "aspect_bazel_lib~",
-            "tar.bzl",
-            "tar.bzl~"
-          ],
-          [
-            "aspect_rules_js~",
-            "aspect_bazel_lib",
-            "aspect_bazel_lib~"
-          ],
-          [
-            "aspect_rules_js~",
-            "aspect_rules_js",
-            "aspect_rules_js~"
-          ],
-          [
-            "aspect_rules_js~",
-            "aspect_tools_telemetry_report",
-            "aspect_tools_telemetry~~telemetry~aspect_tools_telemetry_report"
-          ],
-          [
-            "aspect_rules_js~",
-            "bazel_features",
-            "bazel_features~"
-          ],
-          [
-            "aspect_rules_js~",
-            "bazel_lib",
-            "bazel_lib~"
-          ],
-          [
-            "aspect_rules_js~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "aspect_rules_js~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "bazel_features~",
-            "bazel_features_globals",
-            "bazel_features~~version_extension~bazel_features_globals"
-          ],
-          [
-            "bazel_features~",
-            "bazel_features_version",
-            "bazel_features~~version_extension~bazel_features_version"
-          ],
-          [
-            "bazel_lib~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "bazel_lib~",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "tar.bzl~",
-            "aspect_bazel_lib",
-            "aspect_bazel_lib~"
-          ],
-          [
-            "tar.bzl~",
-            "bazel_skylib",
-            "bazel_skylib~"
-          ],
-          [
-            "tar.bzl~",
-            "tar.bzl",
-            "tar.bzl~"
           ]
         ]
       }
@@ -671,7 +521,7 @@
         "bzlTransitiveDigest": "4u3D2Q8KMDICnG3iuTymzgYbT7m2jCBOpw/XEDnM+jM=",
         "usagesDigest": "r4NUgxQE957p2kkhVEgIoSH0kfzVEyFLLzN40ra5yJw=",
         "recordedFileInputs": {
-          "@@//package.json": "e439f77c61ac1d936ce3418d11fcac22be7b6404f9532bda0975f68a4297f5d6"
+          "@@//package.json": "0eaa8f96d525339070b700b35dc10ff4ef87c7f5f40a4700c8f4e5ec5ea1e6af"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -706,7 +556,7 @@
     "@@aspect_tools_telemetry~//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "t+iDPp0P+D3g6hivmTd4uo98vBSOzl5cB6AawEjqu2s=",
+        "usagesDigest": "zGgjRUWBj18KUD1x7kBJlpHb3lkSYwm52TlErZQKpbs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -716,7 +566,7 @@
             "ruleClassName": "tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_js": "2.9.2",
+                "aspect_rules_js": "3.1.2",
                 "aspect_rules_ts": "3.8.5",
                 "aspect_rules_swc": "2.6.2",
                 "aspect_tools_telemetry": "0.3.3"
@@ -1176,7 +1026,7 @@
     "@@rules_nodejs~//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "Te5oKJ05hJU0hA9slK5PBFE27z0PKTY2k/jCVHpuhL4=",
+        "usagesDigest": "A0C7Ydnj7w0IzVCJoRZsPN2YdkeYT0uShyXTIAuIZAc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1320,7 +1170,7 @@
     },
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "nJRIEv8hyrB94Y/Mjp6cgbWI4I+pDjtOUttg9vmSL4I=",
+        "bzlTransitiveDigest": "svspqBJM6SJ1Y9/z6Ikc8hJvuccUMSSz/kJA1ruyo1s=",
         "usagesDigest": "hAcgB/SJl4OT/1pwDoboRBg1dKEqTs9LMkwunITLeyg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1986,71 +1836,10 @@
         ]
       }
     },
-    "@@tar.bzl~//tar:extensions.bzl%toolchains": {
-      "general": {
-        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
-        "usagesDigest": "I6HvqeURBJAsVftolZUnMjAJqsIpyPsnCw4Sngx2dSg=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "bsd_tar_toolchains": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:toolchain.bzl",
-            "ruleClassName": "tar_toolchains_repo",
-            "attributes": {
-              "user_repository_name": "bsd_tar_toolchains"
-            }
-          },
-          "bsd_tar_toolchains_darwin_amd64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_amd64"
-            }
-          },
-          "bsd_tar_toolchains_darwin_arm64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_arm64"
-            }
-          },
-          "bsd_tar_toolchains_linux_amd64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_amd64"
-            }
-          },
-          "bsd_tar_toolchains_linux_arm64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_arm64"
-            }
-          },
-          "bsd_tar_toolchains_windows_amd64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_amd64"
-            }
-          },
-          "bsd_tar_toolchains_windows_arm64": {
-            "bzlFile": "@@tar.bzl~//tar/toolchain:platforms.bzl",
-            "ruleClassName": "bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_arm64"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@yq.bzl~//yq:extensions.bzl%yq": {
       "general": {
-        "bzlTransitiveDigest": "61Uz+o5PnlY0jJfPZEUNqsKxnM/UCLeWsn5VVCc8u5Y=",
-        "usagesDigest": "bIxL1iOc27/N1kOtSvmFz78f2t5UG/igKD4PiTidq98=",
+        "bzlTransitiveDigest": "tDqk+ntWTdxNAWPDjRY1uITgHbti2jcXR5ZdinltBs0=",
+        "usagesDigest": "ZegDBZEVme/bwhrGMzE+jIU/K9rUs/TDS4GXdN5RxAs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2060,7 +1849,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "darwin_amd64",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_darwin_arm64": {
@@ -2068,7 +1857,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "darwin_arm64",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_linux_amd64": {
@@ -2076,7 +1865,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "linux_amd64",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_linux_arm64": {
@@ -2084,7 +1873,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "linux_arm64",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_linux_s390x": {
@@ -2092,7 +1881,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "linux_s390x",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_linux_riscv64": {
@@ -2100,7 +1889,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "linux_riscv64",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_linux_ppc64le": {
@@ -2108,7 +1897,7 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "linux_ppc64le",
-              "version": "4.45.1"
+              "version": "4.45.2"
             }
           },
           "yq_windows_amd64": {
@@ -2116,7 +1905,15 @@
             "ruleClassName": "yq_platform_repo",
             "attributes": {
               "platform": "windows_amd64",
-              "version": "4.45.1"
+              "version": "4.45.2"
+            }
+          },
+          "yq_windows_arm64": {
+            "bzlFile": "@@yq.bzl~//yq/toolchain:platforms.bzl",
+            "ruleClassName": "yq_platform_repo",
+            "attributes": {
+              "platform": "windows_arm64",
+              "version": "4.45.2"
             }
           },
           "yq_toolchains": {

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -10,39 +10,32 @@
 
 ---
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.5
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-kafka:7.9.5
+    image: confluentinc/cp-kafka:8.2.1
     container_name: broker
     ports:
       - "9092:9092"
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://broker:29092,CONTROLLER://broker:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     healthcheck:
-      test: nc -z localhost 9092 || exit -1
+      test: kafka-broker-api-versions --bootstrap-server localhost:9092
       interval: 5s
       timeout: 10s
       retries: 10
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.9.5
+    image: confluentinc/cp-schema-registry:8.2.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/learn/kafka/docker-compose.yml
+++ b/learn/kafka/docker-compose.yml
@@ -1,34 +1,26 @@
 ---
-version: "3"
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.5
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-kafka:7.9.5
+    image: confluentinc/cp-kafka:8.2.1
     container_name: broker
     ports:
       - "9092:9092"
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://broker:29092,CONTROLLER://broker:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.9.5
+    image: confluentinc/cp-schema-registry:8.2.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:

--- a/learn/kafka_transactional/docker-compose.yml
+++ b/learn/kafka_transactional/docker-compose.yml
@@ -1,27 +1,18 @@
-version: "3.1"
-
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.5
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-kafka:7.9.5
+    image: confluentinc/cp-kafka:8.2.1
     container_name: broker
     ports:
       - "9092:9092"
-    depends_on:
-      - zookeeper
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_INTERNAL://broker:29092,CONTROLLER://broker:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1

--- a/learn/testcontainers/src/test/java/lab/learn/testcontainers/kafka/KafkaTest.java
+++ b/learn/testcontainers/src/test/java/lab/learn/testcontainers/kafka/KafkaTest.java
@@ -13,16 +13,16 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 public class KafkaTest {
   @Container
-  public KafkaContainer kafka =
-      new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.1"));
+  public ConfluentKafkaContainer kafka =
+      new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:8.2.1"));
 
   @Test
   public void getBootstrapServers_isNotBlank() {

--- a/maven_install.json
+++ b/maven_install.json
@@ -20,7 +20,7 @@
     "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": 166979784,
     "com.netflix.graphql.dgs:graphql-dgs-platform-dependencies": -343102663,
     "com.squareup.okhttp3:okhttp-jvm": -674460980,
-    "io.confluent:kafka-protobuf-serializer": -1992835043,
+    "io.confluent:kafka-protobuf-serializer": 494677790,
     "jakarta.servlet:jakarta.servlet-api": 2120044853,
     "org.apache.commons:commons-lang3": 597143964,
     "org.apache.kafka:kafka-clients": -1662559649,
@@ -160,7 +160,7 @@
     "com.github.victools:jsonschema-module-swagger-2": -1971626592,
     "com.github.victools:jsonschema-module-swagger-2:jar:sources": -776422092,
     "com.google.adk:google-adk": -620516450,
-    "com.google.adk:google-adk-dev": 1960476275,
+    "com.google.adk:google-adk-dev": -1370599652,
     "com.google.adk:google-adk-dev:jar:sources": 1470566881,
     "com.google.adk:google-adk:jar:sources": 406327095,
     "com.google.android:annotations": 1863337959,
@@ -352,23 +352,23 @@
     "commons-logging:commons-logging:jar:sources": 368136215,
     "commons-validator:commons-validator": 1603929829,
     "commons-validator:commons-validator:jar:sources": 1817682945,
-    "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64": -183445712,
+    "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64": 668869089,
     "guru.nidi.com.kitfox:svgSalamander": 600393034,
     "guru.nidi.com.kitfox:svgSalamander:jar:sources": -582112426,
-    "guru.nidi:graphviz-java": 628901442,
+    "guru.nidi:graphviz-java": -452118542,
     "guru.nidi:graphviz-java:jar:sources": 1548030905,
-    "io.confluent:common-utils": -94112330,
-    "io.confluent:common-utils:jar:sources": 1180652762,
-    "io.confluent:kafka-protobuf-provider": -352319858,
-    "io.confluent:kafka-protobuf-provider:jar:sources": -1940808940,
-    "io.confluent:kafka-protobuf-serializer": 494661869,
-    "io.confluent:kafka-protobuf-serializer:jar:sources": 1453538367,
-    "io.confluent:kafka-protobuf-types": -555090050,
-    "io.confluent:kafka-protobuf-types:jar:sources": 1233857851,
-    "io.confluent:kafka-schema-registry-client": 2070559791,
-    "io.confluent:kafka-schema-registry-client:jar:sources": -1685048376,
-    "io.confluent:kafka-schema-serializer": -568683977,
-    "io.confluent:kafka-schema-serializer:jar:sources": 1073439344,
+    "io.confluent:common-utils": -887925531,
+    "io.confluent:common-utils:jar:sources": 86133313,
+    "io.confluent:kafka-protobuf-provider": -288796949,
+    "io.confluent:kafka-protobuf-provider:jar:sources": -201417505,
+    "io.confluent:kafka-protobuf-serializer": -223972168,
+    "io.confluent:kafka-protobuf-serializer:jar:sources": 1978064227,
+    "io.confluent:kafka-protobuf-types": -1202994179,
+    "io.confluent:kafka-protobuf-types:jar:sources": 777640027,
+    "io.confluent:kafka-schema-registry-client": 556760819,
+    "io.confluent:kafka-schema-registry-client:jar:sources": 1457677488,
+    "io.confluent:kafka-schema-serializer": -1362268322,
+    "io.confluent:kafka-schema-serializer:jar:sources": -2071364373,
     "io.dropwizard.metrics:metrics-core": -1163050132,
     "io.dropwizard.metrics:metrics-core:jar:sources": 2118762524,
     "io.grpc:grpc-alts": 1109695342,
@@ -2066,9 +2066,9 @@
       },
       "version": "1.7"
     },
-    "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64": {
+    "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64": {
       "shasums": {
-        "jar": "3bd4786967f454bfa3a44dfda0ef33222665b7cefcea67dee5edef45f4e3cc08"
+        "jar": "832e5fc5fcce69e2b30e8dfaa767ac7ff7b019239beaf97214e0ebf68bff9b2e"
       },
       "version": "4.6.0"
     },
@@ -2088,45 +2088,45 @@
     },
     "io.confluent:common-utils": {
       "shasums": {
-        "jar": "c5828ad798d06005becd79bb7e6eb848357a8e1833f2487cc796621853e61564",
-        "sources": "d211a20c9221404ec7ebb6c4467cbbacc3795bde6f7b73701275d5ca3c8cfc38"
+        "jar": "3c1326d4020cb7693346ebdd2d8886c1dbabc902c8a333644b4b796049be32d9",
+        "sources": "14d77e68d21fecec7792223e18f8107026698ceaed793776f607575db332cf13"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.confluent:kafka-protobuf-provider": {
       "shasums": {
-        "jar": "1f9344ce2b8a0e76868976d26355c717d9b99f11eb6c14575f8b84ef4365cab4",
-        "sources": "03bc022f1df4517488ea3964ef0b35974074d61573a7e31e016f7f0b87e4079f"
+        "jar": "654cddf16f136f3083cd33b8f33036b457d30b6e27bdefb9d29e92709fc1e894",
+        "sources": "7347ea894cfb224b6adb29280b40864c8805e8f1331df773e89277338df76721"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.confluent:kafka-protobuf-serializer": {
       "shasums": {
-        "jar": "d57d87b00ae21a5174779a2cd06a0a7224bcf16ac21089fe27f770299cb317e7",
-        "sources": "5c7152c5297b646004e0f0c15129b10073d70a60e9371fe09c9621af13e2cf8b"
+        "jar": "bea9b255f31c00ae5c60647982c0f29756b718c87e1db9079717af490c5ef3a3",
+        "sources": "b6eb656ab7c2a28f6a3ea8f5cd9c84c0a825210b41472eef05eca5dfd946bf06"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.confluent:kafka-protobuf-types": {
       "shasums": {
-        "jar": "4d5b3f898f81fb576113d2cd36689bb8f60f831be2a7469526c75af37358a3ae",
-        "sources": "00e0215457403556cb2cb6cc055fd6eacb6b211e7a7244a96e2ae069c6b3bb82"
+        "jar": "f719da893b23a0e7aff3f5143d19168622de3e16f8c4c3443f68e8f4c6998493",
+        "sources": "4fda8f762ac4795c5a6663b95b08d4c55bcdbef445a42189601edfd546373af1"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.confluent:kafka-schema-registry-client": {
       "shasums": {
-        "jar": "cb3d90a3867a2e5052ada7a9cb64883e48d7ca2048accc10457f5deb421c5b80",
-        "sources": "d16e4623076d0a3e021ee97816da59f22af2a769aa298d24f794812a23fbfbdd"
+        "jar": "de1d7ef36edfee26db66abe3611170dd7d19d26089016f2b0943d2268dc8d455",
+        "sources": "a3f2210455241070a9fc2a984f75b7095adcf39535f5ef37d4f9336faa8641eb"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.confluent:kafka-schema-serializer": {
       "shasums": {
-        "jar": "2116d7542590bb2d760e02d72ea3ff9c986a86b239301fc467d8ac80d82f8454",
-        "sources": "403b14dbf93be5db664361be3763a4cc00f57a7c4a20aaa31937ebdb42080732"
+        "jar": "bebb9cdf5772a5aa64cd46fde1839a6f901af3908c17ba7dee3b70cf0f0d4d23",
+        "sources": "96f2ebc8428c20d7f067c58c9411a8c0af7d0a6722c512cf90fb2153b2daddc6"
       },
-      "version": "8.2.0"
+      "version": "8.2.1"
     },
     "io.dropwizard.metrics:metrics-core": {
       "shasums": {
@@ -5100,7 +5100,7 @@
     ],
     "guru.nidi:graphviz-java": [
       "com.google.code.findbugs:jsr305",
-      "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64",
+      "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64",
       "guru.nidi.com.kitfox:svgSalamander",
       "net.arnx:nashorn-promise",
       "org.apache.commons:commons-exec",
@@ -7722,7 +7722,7 @@
       "org.apache.commons.validator.routines.checkdigit",
       "org.apache.commons.validator.util"
     ],
-    "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64": [
+    "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64": [
       "com.eclipsesource.v8",
       "com.eclipsesource.v8.debug",
       "com.eclipsesource.v8.debug.mirror",
@@ -12983,7 +12983,7 @@
       "commons-logging:commons-logging:jar:sources",
       "commons-validator:commons-validator",
       "commons-validator:commons-validator:jar:sources",
-      "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64",
+      "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64",
       "guru.nidi.com.kitfox:svgSalamander",
       "guru.nidi.com.kitfox:svgSalamander:jar:sources",
       "guru.nidi:graphviz-java",
@@ -13922,7 +13922,7 @@
       "commons-logging:commons-logging:jar:sources",
       "commons-validator:commons-validator",
       "commons-validator:commons-validator:jar:sources",
-      "guru.nidi.com.eclipsesource.j2v8:j2v8_linux_x86_64",
+      "guru.nidi.com.eclipsesource.j2v8:j2v8_macosx_x86_64",
       "guru.nidi.com.kitfox:svgSalamander",
       "guru.nidi.com.kitfox:svgSalamander:jar:sources",
       "guru.nidi:graphviz-java",

--- a/projects/organizer/e2e/runner.ts
+++ b/projects/organizer/e2e/runner.ts
@@ -27,8 +27,8 @@ const AUTOJOURNAL_TARBALL = `${RUNFILES}/_main/projects/organizer/autojournal/sr
 const AUTOJOURNAL_TAG = "jackvincent/lab-autojournal:latest";
 const PROXY_TARBALL = `${RUNFILES}/_main/infra/local/proxy/load/tarball.tar`;
 const PROXY_TAG = "lab/proxy:latest";
-const KAFKA_IMAGE = "confluentinc/cp-kafka:7.9.5";
-const SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry:7.9.5";
+const KAFKA_IMAGE = "confluentinc/cp-kafka:8.2.1";
+const SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry:8.2.1";
 
 const DOCKER = new Dockerode();
 


### PR DESCRIPTION
## Summary
- Upgrade local Confluent images to `8.2.1` across compose files and the organizer e2e runner.
- Switch the dev Kafka compose setups from ZooKeeper mode to single-node KRaft combined mode.
- Update the Java Testcontainers Kafka test to use `ConfluentKafkaContainer` and align the protobuf serializer to `8.2.1`.
- Remove the stale `kafka-protobuf-serializer` failure note from `AGENTS.md`.

## Testing
- `bazel test //learn/testcontainers/src/test/java/lab/learn/testcontainers/kafka:tests`
- `bazel test //learn/kafka/src/test/java/lab/learn/kafka:all //projects/organizer/e2e:ts_typecheck_test //projects/organizer/e2e:ts_transitive_typecheck_test`
- `bazel test //projects/organizer/e2e:e2e`
- `bazel test //...`
- `docker compose config --quiet` for the updated Kafka compose files