### PR TITLE
Handle Bzlmod lockfile repins in Renovate automation

### DIFF
--- a/tools/ci/renovate_repin.sh
+++ b/tools/ci/renovate_repin.sh
@@ -8,15 +8,24 @@ write_summary() {
   fi
 }
 
-REPIN=1 bazel run @maven//:pin
+run_repins() {
+  bazel mod deps --lockfile_mode=update
+  REPIN=1 bazel run @maven//:pin
+}
 
-if git diff --quiet -- maven_install.json; then
-  write_summary "No repin changes required for \`maven_install.json\` on the PR merge checkout."
+changed_lockfiles() {
+  ! git diff --quiet -- MODULE.bazel.lock maven_install.json
+}
+
+run_repins
+
+if ! changed_lockfiles; then
+  write_summary "No repin changes required for \`MODULE.bazel.lock\` or \`maven_install.json\` on the PR merge checkout."
   exit 0
 fi
 
 if [[ "${IS_FORK:-false}" == "true" ]]; then
-  write_summary "Repin required, but this PR is from a fork so CI cannot push \`maven_install.json\`."
+  write_summary "Repin required, but this PR is from a fork so CI cannot push generated lockfiles."
   exit 1
 fi
 
@@ -29,17 +38,17 @@ fi
 git checkout -- .
 git fetch origin "${GITHUB_HEAD_REF}"
 git checkout -B "${GITHUB_HEAD_REF}" "origin/${GITHUB_HEAD_REF}"
-REPIN=1 bazel run @maven//:pin
+run_repins
 
-if git diff --quiet -- maven_install.json; then
+if ! changed_lockfiles; then
   write_summary "Repin required on merge checkout but source branch has no lockfile diff. Rebase or refresh the PR branch."
   exit 1
 fi
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git add maven_install.json
-git commit -m "chore: repin maven_install.json"
+git add MODULE.bazel.lock maven_install.json
+git commit -m "chore: repin generated lockfiles"
 git push origin "HEAD:${GITHUB_HEAD_REF}"
 
 write_summary "Repin commit pushed to \`${GITHUB_HEAD_REF}\`; failing this run intentionally so follow-up CI runs on the updated branch."


### PR DESCRIPTION
## Summary
- Update the Renovate repin workflow to refresh `MODULE.bazel.lock` with `bazel mod deps --lockfile_mode=update` before running the Maven pin.
- Commit generated changes from both `MODULE.bazel.lock` and `maven_install.json` when either repin produces output.
- Keep automated Renovate PRs mergeable when Bazel module updates introduce new registry checksums.

## Testing
- `bash -n tools/ci/renovate_repin.sh`
- Ran `bazel mod deps --lockfile_mode=update` locally to confirm the lockfile refresh path is valid on the current checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline to improve handling of dependency lockfiles during automated refresh processes
  * Strengthened validation and error detection for lockfile consistency across build configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackvincentnz/lab/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->