### PR TITLE
ci: repin on package updates

### DIFF
--- a/.github/workflows/renovate-repin.yml
+++ b/.github/workflows/renovate-repin.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - MODULE.bazel
+      - package.json
+      - pnpm-lock.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Re-pinning was only triggered due to MODULE.bazel changes. It should also include other inputs to the module.