### PR TITLE
fix(deps): upgrade deps with vulnerabilities

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,7 +81,7 @@ maven.install(
         "org.springframework.boot:spring-boot-starter-web",
         "org.springframework.boot:spring-boot-starter-webflux",
         "redis.clients:jedis",
-        "org.postgresql:postgresql",
+        "org.postgresql:postgresql:42.7.11",
         "org.springframework.boot:spring-boot-starter-test",
         "org.springframework.kafka:spring-kafka-test",
         "org.testcontainers:testcontainers",
@@ -98,6 +98,9 @@ maven.install(
         "com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core:8.5.0",
         "com.github.ajalt.clikt:clikt-jvm:4.4.0",  # explicitly depend on the jvm version rather than the kotlin one linked from com.netflix.graphql.dgs.codegen:graphql-dgs-codegen-core
         "com.squareup.okhttp3:okhttp-jvm:5.3.2",
+        "org.apache.tomcat.embed:tomcat-embed-core:11.0.22",
+        "org.apache.tomcat.embed:tomcat-embed-el:11.0.22",
+        "org.apache.tomcat.embed:tomcat-embed-websocket:11.0.22",
     ],
     boms = [
         "io.netty:netty-bom:4.2.15.Final",

--- a/maven_install.json
+++ b/maven_install.json
@@ -31,10 +31,13 @@
     "org.apache.kafka:kafka-streams": 1473637962,
     "org.apache.kafka:kafka-streams-test-utils": -541626037,
     "org.apache.kafka:kafka_2.13": 1972780171,
+    "org.apache.tomcat.embed:tomcat-embed-core": 431364413,
+    "org.apache.tomcat.embed:tomcat-embed-el": -1823527739,
+    "org.apache.tomcat.embed:tomcat-embed-websocket": 1945932545,
     "org.eclipse.jetty:jetty-reactive-httpclient": 1555298607,
     "org.junit.platform:junit-platform-launcher": -354104948,
     "org.junit.platform:junit-platform-reporting": 1896713402,
-    "org.postgresql:postgresql": -253651910,
+    "org.postgresql:postgresql": -1963352047,
     "org.springframework.ai:spring-ai-bom": 138558687,
     "org.springframework.ai:spring-ai-starter-mcp-server-webmvc": 741804729,
     "org.springframework.ai:spring-ai-starter-model-google-genai": 1893382336,
@@ -123,11 +126,11 @@
     "com.github.victools:jsonschema-module-swagger-2:jar:sources": -1497562568,
     "com.google.api.grpc:proto-google-common-protos": 609060832,
     "com.google.api.grpc:proto-google-common-protos:jar:sources": 1617852759,
-    "com.google.api:api-common": 910116564,
+    "com.google.api:api-common": -1781742575,
     "com.google.api:api-common:jar:sources": -894782275,
     "com.google.auth:google-auth-library-credentials": 942630605,
     "com.google.auth:google-auth-library-credentials:jar:sources": 1050676971,
-    "com.google.auth:google-auth-library-oauth2-http": -759335737,
+    "com.google.auth:google-auth-library-oauth2-http": -1936519376,
     "com.google.auth:google-auth-library-oauth2-http:jar:sources": -569959045,
     "com.google.auto.value:auto-value-annotations": 641018093,
     "com.google.auto.value:auto-value-annotations:jar:sources": -315473772,
@@ -137,15 +140,15 @@
     "com.google.code.gson:gson:jar:sources": 907899269,
     "com.google.errorprone:error_prone_annotations": 1527418394,
     "com.google.errorprone:error_prone_annotations:jar:sources": 1371598517,
-    "com.google.genai:google-genai": -330243908,
+    "com.google.genai:google-genai": 295204662,
     "com.google.genai:google-genai:jar:sources": 1676143318,
     "com.google.guava:failureaccess": -718864417,
     "com.google.guava:failureaccess:jar:sources": -527872939,
-    "com.google.guava:guava": 585004560,
+    "com.google.guava:guava": 1719674436,
     "com.google.guava:guava:jar:sources": -1734233239,
     "com.google.guava:listenablefuture": 1079558157,
-    "com.google.http-client:google-http-client": -1561508850,
-    "com.google.http-client:google-http-client-gson": -49615346,
+    "com.google.http-client:google-http-client": 1238686218,
+    "com.google.http-client:google-http-client-gson": 665313055,
     "com.google.http-client:google-http-client-gson:jar:sources": 1352765986,
     "com.google.http-client:google-http-client:jar:sources": -1639480500,
     "com.google.j2objc:j2objc-annotations": -404209759,
@@ -212,7 +215,7 @@
     "com.squareup.okio:okio:jar:sources": 410238119,
     "com.squareup.wire:wire-runtime-jvm": -1752136960,
     "com.squareup.wire:wire-runtime-jvm:jar:sources": 983012095,
-    "com.squareup.wire:wire-schema-jvm": 176434101,
+    "com.squareup.wire:wire-schema-jvm": 352521806,
     "com.squareup.wire:wire-schema-jvm:jar:sources": -1743927679,
     "com.squareup:kotlinpoet": -1583991777,
     "com.squareup:kotlinpoet-jvm": -1912329412,
@@ -242,15 +245,15 @@
     "commons-validator:commons-validator:jar:sources": 1288604053,
     "io.confluent:common-utils": -1683601754,
     "io.confluent:common-utils:jar:sources": -668046586,
-    "io.confluent:kafka-protobuf-provider": -1014925229,
+    "io.confluent:kafka-protobuf-provider": 1874067259,
     "io.confluent:kafka-protobuf-provider:jar:sources": 1530162600,
-    "io.confluent:kafka-protobuf-serializer": -1671103055,
+    "io.confluent:kafka-protobuf-serializer": -1830852624,
     "io.confluent:kafka-protobuf-serializer:jar:sources": -1635849564,
     "io.confluent:kafka-protobuf-types": 2126581442,
     "io.confluent:kafka-protobuf-types:jar:sources": 1718154412,
-    "io.confluent:kafka-schema-registry-client": -1943409470,
+    "io.confluent:kafka-schema-registry-client": -978232919,
     "io.confluent:kafka-schema-registry-client:jar:sources": 804603703,
-    "io.confluent:kafka-schema-serializer": -1119078944,
+    "io.confluent:kafka-schema-serializer": -407142687,
     "io.confluent:kafka-schema-serializer:jar:sources": -1844922852,
     "io.grpc:grpc-api": 32128397,
     "io.grpc:grpc-api:jar:sources": -251192845,
@@ -319,7 +322,7 @@
     "io.netty:netty-transport:jar:sources": -1344318581,
     "io.opencensus:opencensus-api": -2128472383,
     "io.opencensus:opencensus-api:jar:sources": 1085904850,
-    "io.opencensus:opencensus-contrib-http-util": -1119643163,
+    "io.opencensus:opencensus-contrib-http-util": 2094984456,
     "io.opencensus:opencensus-contrib-http-util:jar:sources": -879181311,
     "io.projectreactor.kotlin:reactor-kotlin-extensions": -673302600,
     "io.projectreactor.kotlin:reactor-kotlin-extensions:jar:sources": -266977830,
@@ -429,12 +432,14 @@
     "org.apache.logging.log4j:log4j-core:jar:sources": -310222995,
     "org.apache.logging.log4j:log4j-to-slf4j": 1902537030,
     "org.apache.logging.log4j:log4j-to-slf4j:jar:sources": 1332324341,
-    "org.apache.tomcat.embed:tomcat-embed-core": 895933409,
-    "org.apache.tomcat.embed:tomcat-embed-core:jar:sources": 1856682060,
-    "org.apache.tomcat.embed:tomcat-embed-el": -2091587018,
-    "org.apache.tomcat.embed:tomcat-embed-el:jar:sources": -208789581,
-    "org.apache.tomcat.embed:tomcat-embed-websocket": -1722723367,
-    "org.apache.tomcat.embed:tomcat-embed-websocket:jar:sources": 1787496570,
+    "org.apache.tomcat.embed:tomcat-embed-core": -1021201612,
+    "org.apache.tomcat.embed:tomcat-embed-core:jar:sources": 610251870,
+    "org.apache.tomcat.embed:tomcat-embed-el": 1305005618,
+    "org.apache.tomcat.embed:tomcat-embed-el:jar:sources": 1468704337,
+    "org.apache.tomcat.embed:tomcat-embed-websocket": -1941676928,
+    "org.apache.tomcat.embed:tomcat-embed-websocket:jar:sources": 1025115480,
+    "org.apache.tomcat:tomcat-annotations-api": 925375027,
+    "org.apache.tomcat:tomcat-annotations-api:jar:sources": -1810197536,
     "org.apiguardian:apiguardian-api": 1279798469,
     "org.apiguardian:apiguardian-api:jar:sources": 729595858,
     "org.assertj:assertj-core": 504285799,
@@ -443,8 +448,8 @@
     "org.awaitility:awaitility:jar:sources": -74464497,
     "org.bitbucket.b_c:jose4j": -36599002,
     "org.bitbucket.b_c:jose4j:jar:sources": 1703050659,
-    "org.checkerframework:checker-qual": -1286069869,
-    "org.checkerframework:checker-qual:jar:sources": 1329524901,
+    "org.checkerframework:checker-qual": -1158206121,
+    "org.checkerframework:checker-qual:jar:sources": -1169439178,
     "org.eclipse.jetty.compression:jetty-compression-common": 756174200,
     "org.eclipse.jetty.compression:jetty-compression-common:jar:sources": -2061932775,
     "org.eclipse.jetty.compression:jetty-compression-gzip": -682434585,
@@ -535,8 +540,8 @@
     "org.ow2.asm:asm:jar:sources": -1707020066,
     "org.pcollections:pcollections": -311488717,
     "org.pcollections:pcollections:jar:sources": 238016638,
-    "org.postgresql:postgresql": 2077473025,
-    "org.postgresql:postgresql:jar:sources": 115218962,
+    "org.postgresql:postgresql": -457385259,
+    "org.postgresql:postgresql:jar:sources": -1604401690,
     "org.reactivestreams:reactive-streams": 1281941191,
     "org.reactivestreams:reactive-streams:jar:sources": -1454226778,
     "org.rnorth.duct-tape:duct-tape": 133152594,
@@ -585,7 +590,7 @@
     "org.springframework.ai:spring-ai-client-chat:jar:sources": 2063373128,
     "org.springframework.ai:spring-ai-commons": 737904165,
     "org.springframework.ai:spring-ai-commons:jar:sources": 1209990732,
-    "org.springframework.ai:spring-ai-google-genai": -1160604898,
+    "org.springframework.ai:spring-ai-google-genai": 423760879,
     "org.springframework.ai:spring-ai-google-genai:jar:sources": 675136181,
     "org.springframework.ai:spring-ai-mcp": -203058504,
     "org.springframework.ai:spring-ai-mcp-annotations": 1589607316,
@@ -599,8 +604,8 @@
     "org.springframework.ai:spring-ai-openai:jar:sources": -602000150,
     "org.springframework.ai:spring-ai-retry": 1761844068,
     "org.springframework.ai:spring-ai-retry:jar:sources": -1605560550,
-    "org.springframework.ai:spring-ai-starter-mcp-server-webmvc": 414028102,
-    "org.springframework.ai:spring-ai-starter-model-google-genai": -231443872,
+    "org.springframework.ai:spring-ai-starter-mcp-server-webmvc": 1643947420,
+    "org.springframework.ai:spring-ai-starter-model-google-genai": -1462560134,
     "org.springframework.ai:spring-ai-starter-model-ollama": 370684618,
     "org.springframework.ai:spring-ai-starter-model-openai": -2041620522,
     "org.springframework.ai:spring-ai-template-st": -432172078,
@@ -683,13 +688,13 @@
     "org.springframework.boot:spring-boot-starter-security:jar:sources": 1743676768,
     "org.springframework.boot:spring-boot-starter-test": 2064634742,
     "org.springframework.boot:spring-boot-starter-test:jar:sources": 646966594,
-    "org.springframework.boot:spring-boot-starter-tomcat": -927451912,
-    "org.springframework.boot:spring-boot-starter-tomcat-runtime": -371762972,
+    "org.springframework.boot:spring-boot-starter-tomcat": -1894871732,
+    "org.springframework.boot:spring-boot-starter-tomcat-runtime": 232821806,
     "org.springframework.boot:spring-boot-starter-tomcat-runtime:jar:sources": 1844487672,
     "org.springframework.boot:spring-boot-starter-tomcat:jar:sources": -1278142313,
-    "org.springframework.boot:spring-boot-starter-validation": 457101666,
+    "org.springframework.boot:spring-boot-starter-validation": -1575328514,
     "org.springframework.boot:spring-boot-starter-validation:jar:sources": 1904860676,
-    "org.springframework.boot:spring-boot-starter-web": 1304264498,
+    "org.springframework.boot:spring-boot-starter-web": -1489191694,
     "org.springframework.boot:spring-boot-starter-web:jar:sources": -520550530,
     "org.springframework.boot:spring-boot-starter-webclient": 128378586,
     "org.springframework.boot:spring-boot-starter-webclient:jar:sources": 2056056838,
@@ -700,11 +705,11 @@
     "org.springframework.boot:spring-boot-test-autoconfigure": -834160310,
     "org.springframework.boot:spring-boot-test-autoconfigure:jar:sources": 2034664639,
     "org.springframework.boot:spring-boot-test:jar:sources": -1332713625,
-    "org.springframework.boot:spring-boot-tomcat": 467976714,
+    "org.springframework.boot:spring-boot-tomcat": 2040882099,
     "org.springframework.boot:spring-boot-tomcat:jar:sources": 1121073132,
     "org.springframework.boot:spring-boot-transaction": -1561469472,
     "org.springframework.boot:spring-boot-transaction:jar:sources": -1110100170,
-    "org.springframework.boot:spring-boot-validation": 1308327793,
+    "org.springframework.boot:spring-boot-validation": 1650568402,
     "org.springframework.boot:spring-boot-validation:jar:sources": -434338936,
     "org.springframework.boot:spring-boot-web-server": -536053243,
     "org.springframework.boot:spring-boot-web-server:jar:sources": 1338921549,
@@ -823,7 +828,6 @@
     "org.eclipse.jetty:jetty-reactive-httpclient": "org.eclipse.jetty:jetty-reactive-httpclient:4.1.4",
     "org.junit.platform:junit-platform-launcher": "org.junit.platform:junit-platform-launcher:6.0.3",
     "org.junit.platform:junit-platform-reporting": "org.junit.platform:junit-platform-reporting:6.0.3",
-    "org.postgresql:postgresql": "org.postgresql:postgresql:42.7.10",
     "org.springframework.ai:spring-ai-starter-mcp-server-webmvc": "org.springframework.ai:spring-ai-starter-mcp-server-webmvc:2.0.0-RC1",
     "org.springframework.ai:spring-ai-starter-model-google-genai": "org.springframework.ai:spring-ai-starter-model-google-genai:2.0.0-RC1",
     "org.springframework.ai:spring-ai-starter-model-ollama": "org.springframework.ai:spring-ai-starter-model-ollama:2.0.0-RC1",
@@ -2126,22 +2130,29 @@
     },
     "org.apache.tomcat.embed:tomcat-embed-core": {
       "shasums": {
-        "jar": "5dbe19880b5025e0b9de7c3de81cb837ce79636ea1da39c8d00a66d3add25567",
-        "sources": "c186a8277e1579bf83fd68483ca316d07105e9ff0bc43c24d94037acdbd9518b"
+        "jar": "78cd7cd7c104b6b87142c1b0bd902e1ce005b0245c3cefa8a06759148947200b",
+        "sources": "0bfbdc27e60d4db5b83e0f51193bae5f4bd02ac270fd78b06945e219fc473359"
       },
-      "version": "11.0.21"
+      "version": "11.0.22"
     },
     "org.apache.tomcat.embed:tomcat-embed-el": {
       "shasums": {
-        "jar": "3745cb768f4ed74c2f4af8fc2453992143997019718f71c915d4545fdbef1fb3",
-        "sources": "4b4ed468ef4de687b9e8678a4209926ed941d2a230e5c015e7715fb4ebf09c5b"
+        "jar": "1b34c33b858c141df36c501b4d809e68036c406bca3671a86facae297917c7de",
+        "sources": "da3724004575f5c8fa7e45649f2900ec53e7ecfb502b6ce227ca9cf86b36a156"
       },
-      "version": "11.0.21"
+      "version": "11.0.22"
     },
     "org.apache.tomcat.embed:tomcat-embed-websocket": {
       "shasums": {
-        "jar": "fc64e531c473d627ff121e31bcb5871dee9f241e1fd1d1f1522498208f1a278d",
-        "sources": "01e075259649f811ab3aa1460aa7e8047fb39676b151cc97c2fe4588786defd8"
+        "jar": "210e0c7ab194a76cc7283df0be365276091b042369dae125fb477828ba67e922",
+        "sources": "711f09af528ac5af172c664244bcba4748eac00811ef7c6b52ddd6836b5a4a28"
+      },
+      "version": "11.0.22"
+    },
+    "org.apache.tomcat:tomcat-annotations-api": {
+      "shasums": {
+        "jar": "2f66697030bb986a69043ca3b55b838384c73de50aff1ef5452ae2c90cfaea70",
+        "sources": "cbb5b6aa6e3760b198a75293de3ca0a6de117eb5c3fef5643b68a9486dcbb55e"
       },
       "version": "11.0.21"
     },
@@ -2175,10 +2186,10 @@
     },
     "org.checkerframework:checker-qual": {
       "shasums": {
-        "jar": "0b5bb1a4bdc4e4b1217482fe598efcaab4e1fba7b37f9412639178fc8116fc05",
-        "sources": "fbc4bee8d87f7812d5df2175f5afc247091e3bdf1d641768e91bfe8837539741"
+        "jar": "3fbc2e98f05854c3df16df9abaa955b91b15b3ecac33623208ed6424640ef0f6",
+        "sources": "d6bdee58964cd05aabfca4e44947d3cbdada6bf617ed618b62b3b0d5a21de339"
       },
-      "version": "3.52.0"
+      "version": "3.43.0"
     },
     "org.eclipse.jetty.compression:jetty-compression-common": {
       "shasums": {
@@ -2497,10 +2508,10 @@
     },
     "org.postgresql:postgresql": {
       "shasums": {
-        "jar": "cab1cd67cfa25c25de4348e532298028288a877ba01c77d1619fe45416193387",
-        "sources": "67c81c4c33327a7da3b80d8f65c479cf70439f522de340f364c49f8482f7e1d3"
+        "jar": "1981b31d3993c58702783c1cddf10a34e48c1f413d70ff1cb6def0a143484647",
+        "sources": "5156b9a1076e69ede16266ceb0c20a7ecd0f3f7d5a5a388480333ec8339ee198"
       },
-      "version": "42.7.10"
+      "version": "42.7.11"
     },
     "org.reactivestreams:reactive-streams": {
       "shasums": {
@@ -4279,6 +4290,9 @@
       "org.apache.logging.log4j:log4j-api",
       "org.slf4j:slf4j-api"
     ],
+    "org.apache.tomcat.embed:tomcat-embed-core": [
+      "org.apache.tomcat:tomcat-annotations-api"
+    ],
     "org.apache.tomcat.embed:tomcat-embed-websocket": [
       "org.apache.tomcat.embed:tomcat-embed-core"
     ],
@@ -4437,9 +4451,6 @@
     ],
     "org.opentest4j.reporting:open-test-reporting-tooling-spi": [
       "org.apiguardian:apiguardian-api"
-    ],
-    "org.postgresql:postgresql": [
-      "org.checkerframework:checker-qual"
     ],
     "org.rnorth.duct-tape:duct-tape": [
       "org.jetbrains:annotations"
@@ -7344,6 +7355,11 @@
       "org.apache.tomcat.websocket.pojo",
       "org.apache.tomcat.websocket.server"
     ],
+    "org.apache.tomcat:tomcat-annotations-api": [
+      "jakarta.annotation",
+      "jakarta.annotation.security",
+      "jakarta.annotation.sql"
+    ],
     "org.apiguardian:apiguardian-api": [
       "org.apiguardian.api"
     ],
@@ -7424,14 +7440,12 @@
       "org.checkerframework.checker.interning.qual",
       "org.checkerframework.checker.lock.qual",
       "org.checkerframework.checker.mustcall.qual",
-      "org.checkerframework.checker.nonempty.qual",
       "org.checkerframework.checker.nullness.qual",
       "org.checkerframework.checker.optional.qual",
       "org.checkerframework.checker.propkey.qual",
       "org.checkerframework.checker.regex.qual",
       "org.checkerframework.checker.signature.qual",
       "org.checkerframework.checker.signedness.qual",
-      "org.checkerframework.checker.sqlquotes.qual",
       "org.checkerframework.checker.tainting.qual",
       "org.checkerframework.checker.units.qual",
       "org.checkerframework.common.aliasing.qual",
@@ -10441,6 +10455,8 @@
       "org.apache.tomcat.embed:tomcat-embed-el:jar:sources",
       "org.apache.tomcat.embed:tomcat-embed-websocket",
       "org.apache.tomcat.embed:tomcat-embed-websocket:jar:sources",
+      "org.apache.tomcat:tomcat-annotations-api",
+      "org.apache.tomcat:tomcat-annotations-api:jar:sources",
       "org.apiguardian:apiguardian-api",
       "org.apiguardian:apiguardian-api:jar:sources",
       "org.assertj:assertj-core",
@@ -11179,6 +11195,8 @@
       "org.apache.tomcat.embed:tomcat-embed-el:jar:sources",
       "org.apache.tomcat.embed:tomcat-embed-websocket",
       "org.apache.tomcat.embed:tomcat-embed-websocket:jar:sources",
+      "org.apache.tomcat:tomcat-annotations-api",
+      "org.apache.tomcat:tomcat-annotations-api:jar:sources",
       "org.apiguardian:apiguardian-api",
       "org.apiguardian:apiguardian-api:jar:sources",
       "org.assertj:assertj-core",


### PR DESCRIPTION
- tomcat -> 11.0.22
- postgres -> 42.7.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated PostgreSQL database driver to version 42.7.11 for enhanced stability and compatibility
  * Updated embedded Tomcat components to version 11.0.22 for improved performance and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->