### PR TITLE
Remove Adminer from Kafka transactional compose setup

### DIFF
--- a/learn/kafka_transactional/docker-compose.yml
+++ b/learn/kafka_transactional/docker-compose.yml
@@ -30,9 +30,3 @@ services:
       MYSQL_ROOT_PASSWORD: example
     ports:
       - "3306:3306"
-
-  adminer:
-    image: adminer@sha256:3856143121b0f5d24c952f343db61ee14226985adfc56334d8e877a22388d73e
-    restart: always
-    ports:
-      - "8080:8080"


### PR DESCRIPTION
## Summary
- Remove the `adminer` service from `learn/kafka_transactional/docker-compose.yml`
- Leave the MySQL and Kafka-related services unchanged
- Reduce the local compose footprint by dropping an unused database UI container

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the database administration service from the Kafka transaction learning environment configuration, simplifying the setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->